### PR TITLE
Added exposure for spy via `with`

### DIFF
--- a/kgb/contextmanagers.py
+++ b/kgb/contextmanagers.py
@@ -21,6 +21,6 @@ def spy_on(*args, **kwargs):
     agency = SpyAgency()
     spy = agency.spy_on(*args, **kwargs)
 
-    yield
+    yield spy
 
     spy.unspy()

--- a/kgb/tests.py
+++ b/kgb/tests.py
@@ -473,6 +473,19 @@ class ContextManagerTests(BaseTestCase):
 
         self.assertEqual(obj.do_math, orig_do_math)
 
+    def test_expose_spy(self):
+        """Testing spy_on exposes `spy` via context manager"""
+        obj = MathClass()
+        orig_do_math = obj.do_math
+
+        with spy_on(obj.do_math) as spy:
+            self.assertTrue(isinstance(spy, FunctionSpy))
+
+            result = obj.do_math()
+            self.assertEqual(result, 3)
+
+        self.assertEqual(obj.do_math, orig_do_math)
+
 
 class MixinTests(SpyAgency, unittest.TestCase):
     def test_spy_on(self):


### PR DESCRIPTION
I am using `kgb` with `requests` and noticed that when using the `with` context, the override would not be accessible. For example:

```python
with spy_on(requests.post):
  requests.post # Original `requests.post`, not spy
```

To remedy this, I have exposed the `spy` via `yield`:

```python
with spy_on(requests.post) as spy:
  spy # Our spy for `requests.post`
```

In this PR:

- Added test for exposing `spy` in a `with` call
- Added support for exposing `spy` via `contextmanager`