### PR TITLE
Fixed unspy_all. Setting spies to empty set, not list.

### DIFF
--- a/kgb/agency.py
+++ b/kgb/agency.py
@@ -103,7 +103,7 @@ class SpyAgency(object):
         for spy in self.spies:
             spy.unspy(unregister=False)
 
-        self.spies = []
+        self.spies = set()
 
     def assertHasSpy(self, spy):
         """Assert that a function has a spy.

--- a/kgb/tests/test_spy_agency.py
+++ b/kgb/tests/test_spy_agency.py
@@ -46,7 +46,7 @@ class SpyAgencyTests(TestCase):
         self.assertTrue(hasattr(MathClass.class_do_math, 'spy'))
 
         self.agency.unspy_all()
-        self.assertEqual(self.agency.spies, [])
+        self.assertEqual(self.agency.spies, set())
 
         self.assertEqual(obj.do_math, orig_do_math)
         self.assertEqual(MathClass.class_do_math, self.orig_class_do_math)


### PR DESCRIPTION
`unspy_all` was not working correctly as it set spies to empty list but should be empty set. `SpyAgency` wasn't usable after calling `unspy_all` since it uses `set` methods like `add`.